### PR TITLE
Kursp 279 multilanguage refresh bug

### DIFF
--- a/src/js/3party/uob7.js
+++ b/src/js/3party/uob7.js
@@ -57,6 +57,14 @@ function uobAddComponents() {
   onElementRendered(
     '#content .user_content.enhanced,#content .show-content.enhanced',
     function($content) {
+      //KURSP-279 Multilanguage must be run when content is ready
+      try {
+        // Call multilanguage.perform() last to catch all relevant DOM content
+        mmooc.multilanguage.perform();
+      } catch (e) {
+        console.log(e);
+      }
+
       // Tooltip
       var re = /\[(.*?)\]\((.*?)\)/g;
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,6 @@
 jQuery(function($) {
+  //Multilanguage KURSP-279 Css must be present before javascript is run.
+  mmooc.multilanguage.insertCss();
 
   mmooc.routes.addRouteForPath(/\/$/, function() {
     var parentId = 'wrapper';
@@ -539,13 +541,6 @@ jQuery(function($) {
           function(course) {
             mmooc.util.course = course;
             mmooc.routes.performHandlerForUrl(document.location);
-            try {
-              // Call multilanguage.perform() last to catch all relevant DOM content
-              mmooc.multilanguage.insertCss();
-              mmooc.multilanguage.perform();
-            } catch (e) {
-              console.log(e);
-            }
           },
           function(error) {
             console.error(

--- a/src/js/modules/dataporten.js
+++ b/src/js/modules/dataporten.js
@@ -5,10 +5,10 @@ this.mmooc.dataporten = function() {
     var token = null;
 
 // VARIABLES CHANGED BY GRUNT
-    let request = ['email','longterm', 'openid', 'profile', 'userid-feide', 'groups', 'gk_netgurukpasapi'];
-    let dataportenCallback = 'https://localhost/courses/1?dataportenCallback=1';
-    let dataportenClientId = 'fb2f6378-2d35-4354-8ae8-2e82e2af2a8f';
-    let kpasapiurl = 'https://netgurukpasapi.dataporten-api.no';    
+    let request = ['email','longterm', 'openid', 'profile', 'userid-feide', 'groups', 'gk_kpas'];
+    let dataportenCallback = 'https://bibsys.instructure.com/courses/234?dataportenCallback=1';
+    let dataportenClientId = '823e54e4-9cb7-438f-b551-d1af9de0c2cd';
+    let kpasapiurl = 'https://kpas.dataporten-api.no';    
 
     
     var opts = {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -8,7 +8,7 @@ this.mmooc.settings = {
   defaultNumberOfReviews: 1, // Default number of peer reviews per student in power function
   useDataportenGroups : false,
   filterCourses: true,
-  filterCoursesOnAccountId: [4, 5],
+  filterCoursesOnAccountId: [253],
   disablePeerReviewButton: false,
   principalRoleType: "Skoleleder",
   removeGlobalGradesLink: true,


### PR DESCRIPTION
Når man valgte språk på kursforsiden så oppdaterte adresselinjen seg med &lang=se/nb. Dersom man kjørte en refresh på siden så slo ruten /lang/ til. Men den ruten ble kjørt før multilanguage.insertCss ble kjørt. Jeg har derfor flyttet multilanguage.insertcss helt øverst i main.js fordi denne kan kjøres med en gang, den er kun avhengig av at DOM er ferdig lastet.

Jeg har også flyttet multilanguage.perform inn i callbacken til onElementRendered i uob.js. Dette er for at den ikke skal bli kjørt før innholdet er klart. Innholdet på sidene i Canvas lastes asynkront, og onElementRendered kalles når innholdet er lastet inn. Den gjør det vha. en 200 ms timer som kjøres opp til 60 ganger eller til innholdet er klart.

UoB navnet henger igjen fra det faktum at det er University of Birmingham som laget koden opprinnelig. Men modulen inneholder altså funksjonalitet som kjøres etter at innholdet på en side er klart, og derfor kan man forsvare at multiglanguage.perform kalles derfra.