### PR TITLE
Let the user specify course id when showing group statistics.

### DIFF
--- a/kpas/grupper.html
+++ b/kpas/grupper.html
@@ -33,7 +33,6 @@
      blir denne ikke tatt med i statistikken heller.  
 </p>
 </div>
-Kompetansepakkeid: <input type="text" size="4" id="course_id" name="course_id">
 Fylke:<span id="allefylker"></span>
 <button id="visFylke" disabled onclick="visFylkesStatistikk();">Vis statistikk</button>
 Kommune:<span id="allekommuner"></span>

--- a/kpas/grupper.html
+++ b/kpas/grupper.html
@@ -18,11 +18,11 @@
     <script src="main.js?version=KPAS_IFRAME_VERSION"></script>
 </head>
 <body onload="loadFylker()">
-<h1>Gruppestatistikk fagfornyelsen kompetanse.udir.no</h1>
+<h1>Gruppestatistikk kompetanse.udir.no</h1>
 <div class="uob-info">
     <h2>Hva viser statistikken?</h2>
     <p>Statistikken for bruk av kompetansepakken gir ikke nødvendigvis svar på kvaliteten 
-        i arbeidet med innføring av fagfornyelsen, men kan bidra til innsikt for å 
+        i arbeidet med kompetansepakken, men kan bidra til innsikt for å 
         drive kompetanseutvikling.
     </p>        
     <p>
@@ -33,6 +33,7 @@
      blir denne ikke tatt med i statistikken heller.  
 </p>
 </div>
+Kompetansepakkeid: <input type="text" size="4" id="course_id" name="course_id">
 Fylke:<span id="allefylker"></span>
 <button id="visFylke" disabled onclick="visFylkesStatistikk();">Vis statistikk</button>
 Kommune:<span id="allekommuner"></span>

--- a/kpas/grupper.js
+++ b/kpas/grupper.js
@@ -1,7 +1,18 @@
+function urlParamsToObject() {
+    if (document.location.search === '') return {};
+
+    const search = location.search.substring(1);
+    return parse_query_string(search);
+}
+function getCourseId() {
+    const urlParamsObj = urlParamsToObject();
+    //Course id is defined on global scope such that it is available for the update functions above.
+    return urlParamsObj && urlParamsObj['courseId'];
+}
 
 function visFylkesStatistikk() {
     var fylkesNr = $("#fylker option[value='" + $("#fylke").val() + "']").attr("fylkesnr");
-    var courseId = document.getElementById('course_id').value;
+    var courseId = getCourseId();
     clearTimeout(resizeDebounce);
     d3.select("#table-tooltip").remove();
     d3.select(".table-kpas").remove();
@@ -10,7 +21,7 @@ function visFylkesStatistikk() {
 
 function visKommuneStatistikk() {
     var kommuneNr = $("#kommuner option[value='" + $("#kommune").val() + "']").attr("kommunenr");
-    var courseId = document.getElementById('course_id').value;
+    var courseId = getCourseId();
     clearTimeout(resizeDebounce);
     d3.select("#table-tooltip").remove();
     d3.select(".table-kpas").remove();

--- a/kpas/grupper.js
+++ b/kpas/grupper.js
@@ -1,18 +1,20 @@
 
 function visFylkesStatistikk() {
     var fylkesNr = $("#fylker option[value='" + $("#fylke").val() + "']").attr("fylkesnr");
+    var courseId = document.getElementById('course_id').value;
     clearTimeout(resizeDebounce);
     d3.select("#table-tooltip").remove();
     d3.select(".table-kpas").remove();
-    loadCountyGraphic(360, fylkesNr);
+    loadCountyGraphic(courseId, fylkesNr);
 }  
 
 function visKommuneStatistikk() {
     var kommuneNr = $("#kommuner option[value='" + $("#kommune").val() + "']").attr("kommunenr");
+    var courseId = document.getElementById('course_id').value;
     clearTimeout(resizeDebounce);
     d3.select("#table-tooltip").remove();
     d3.select(".table-kpas").remove();
-    loadMunicipalityGraphic(360, kommuneNr);
+    loadMunicipalityGraphic(courseId, kommuneNr);
 }  
 
 function loadFylker() {


### PR DESCRIPTION
KURSP-345 Gruppestatistikk må vises for alle pakker som har den funksjonaliteten

Testes ved å kompilere opp designet og åpne dist/kpas/grupper.html?courseId=360 f.eks. Deretter kan 360 byttes ut med andre id'er som har rolle- og gruppeverktøy.

