### PR TITLE
KURSP-660: make labels on accordian darker

### DIFF
--- a/src/css/modules/accordion.less
+++ b/src/css/modules/accordion.less
@@ -44,7 +44,7 @@
         font-family: Roboto;
         font-size: 14px;
         color: @textColor;
-        opacity: 0.5;
+        opacity: 0.75;
       }
     }
 


### PR DESCRIPTION
make labels on accordian (åpne / lukke) darker to increase contrast to background.