### PR TITLE
KURSP-660: wcag contrast fixes

### DIFF
--- a/src/css/modules/accordion.less
+++ b/src/css/modules/accordion.less
@@ -44,7 +44,7 @@
         font-family: Roboto;
         font-size: 14px;
         color: @textColor;
-        opacity: 0.5;
+        opacity: 0.75;
       }
     }
 

--- a/src/css/setup/variables.less
+++ b/src/css/setup/variables.less
@@ -48,8 +48,8 @@
 @doneHoverGradientStart: #00c700;
 @doneHoverGradientEnd: #009100;
 
-@greenColor: #00ac18;
-@greenTransparent: rgba(0, 172, 24, 0.1);
+@greenColor: #00a316;
+@greenTransparent: rgba(0, 172, 24, 0.075);
 
 @udirPeach: #EED0C3;
 @udirSteelBlue: #BAC6D8;

--- a/src/css/setup/variablespfdk.less
+++ b/src/css/setup/variablespfdk.less
@@ -46,8 +46,8 @@
 @doneGradientBoxShadow: #a0b530;
 @doneHoverGradientStart: #a0b530;
 @doneHoverGradientEnd: #a0b530;
-@greenColor: #00ac18;
-@greenTransparent: rgba(0, 172, 24, 0.1);
+@greenColor: #00a316;
+@greenTransparent: rgba(0, 172, 24, 0.075);
 
 @white: #fff;
 

--- a/src/css/setup/variablesudir.less
+++ b/src/css/setup/variablesudir.less
@@ -47,8 +47,8 @@
 @doneHoverGradientStart: #00c700;
 @doneHoverGradientEnd: #009100;
 
-@greenColor: #00ac18;
-@greenTransparent: rgba(0, 172, 24, 0.1);
+@greenColor: #00a316;
+@greenTransparent: rgba(0, 172, 24, 0.075);
 
 //Used in peer review
 @westSideColor : #FF8E1A;


### PR DESCRIPTION
- make labels on accordian (åpne / lukke) darker to increase contrast to background.

- in kompetansepakker overview, increase contrast for label "du er registrert i x kompetansepakker". Background lighter and text color darker. The css variables are not used for anything else, so it's safe to change.
