### PR TITLE
KURSP-805: Add az storage '--overwrite' argument

### DIFF
--- a/.github/workflows/build-master-push-azure.yml
+++ b/.github/workflows/build-master-push-azure.yml
@@ -44,7 +44,7 @@ jobs:
           azcliversion: 2.48.1
           inlineScript: |
               az storage blob upload-batch --account-name ${{ env.ACCOUNT_NAME }} \
-                --auth-mode key -s ${{ env.SOURCE }} -d ${{ env.DESTINATION }}
+                --auth-mode key -s ${{ env.SOURCE }} -d ${{ env.DESTINATION }} --overwrite
       # Azure logout - Force step to always run with 'always()', ensures no hanging logins
       - name: logout
         if: always()

--- a/.github/workflows/build-stage-push-azure.yml
+++ b/.github/workflows/build-stage-push-azure.yml
@@ -44,7 +44,7 @@ jobs:
           azcliversion: 2.48.1
           inlineScript: |
               az storage blob upload-batch --account-name ${{ env.ACCOUNT_NAME }} \
-                --auth-mode key -s ${{ env.SOURCE }} -d ${{ env.DESTINATION }}
+                --auth-mode key -s ${{ env.SOURCE }} -d ${{ env.DESTINATION }} --overwrite
       # Azure logout - Force step to always run with 'always()', ensures no hanging logins
       - name: logout
         if: always()


### PR DESCRIPTION
Some files where not pushed by default. Adding '--overwrite' ensures all files get pushed to blob storage.