### PR TITLE
remove entrypoints in webpack that is either not used or do not exist

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -26,7 +26,6 @@ module.exports = (env) => {
         "kompetanseportal-udirdesign-dev": [
           "./src/js/i18n.js",
           "./src/js/main.js",
-          "./src/vue/app.js",
         ],
         badgesafe: [
           "./src/addons/badges/js/main.js",

--- a/webpack.development.config.js
+++ b/webpack.development.config.js
@@ -15,19 +15,16 @@ module.exports = {
       "./src/js/settingsRoot.js",
       "./src/js/utilRoot.js",
       "./src/js/rootaccount.js",
-      "./src/vue/design/index.scss",
     ],
 
     "subaccount-localhost": [
       "./src/js/settingsRoot.js",
       "./src/js/utilRoot.js",
       "./src/js/subaccount.js",
-      "./src/vue/design/index.scss",
     ],
     "kompetanseportalen-localhost": [
       "./src/js/i18n.js",
       "./src/js/main.js",
-      // "./src/vue/app.js",
     ],
     "badges-dev": [
       "./src/addons/badges/js/main.js",


### PR DESCRIPTION
Registered entrypoint in webpack, was deleted, and created problems in build process. So that one is removed along with other entrypoints not used