### PR TITLE
Therese persen kursp 899 bug fix storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm install
 
       - name: Build Storybook
-        run: npm run build-storybook
+        run: GH_PAGES=true npm run build-storybook
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
   "dependencies": {
     "@material-symbols/font-400": "^0.13.0",
     "@vimeo/player": "^2.20.1",
-    "fs": "^0.0.1-security",
     "vue-style-loader": "^4.1.3"
   }
 }

--- a/src/vue/.storybook/main.js
+++ b/src/vue/.storybook/main.js
@@ -1,21 +1,6 @@
 const webpack = require("webpack");
 const path = require("path");
-const fs = require("fs");
 
-// Define possible base directories
-const possibleBaseDirectories = ["/frontend/", "/"];
-
-// Function to find the first existing base directory
-function findExistingBaseDirectory() {
-  for (const baseDir of possibleBaseDirectories) {
-    if (fs.existsSync(baseDir)) {
-      console.error('base dir is: ', baseDir);
-      return baseDir;
-    }
-  }
-  // If none of the directories exist, default to "/"
-  return "/";
-}
 module.exports = {
   stories: ["../**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: [
@@ -44,8 +29,9 @@ module.exports = {
     // Define global constants that can be accessed in your stories
     config.plugins.push(
       new webpack.DefinePlugin({
-        SERVER: JSON.stringify(findExistingBaseDirectory()),
+        SERVER: process.env.GH_PAGES ? JSON.stringify('/frontend/') : JSON.stringify('/'),
       })
+       
     );
     
    return(config);

--- a/src/vue/.storybook/main.js
+++ b/src/vue/.storybook/main.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   staticDirs: [path.resolve(__dirname, "../assets")],
   webpackFinal: async (config) => {
-    // Define global constants that can be accessed in your stories
+    // Define global constants that can be accessed in your stories/ components
     config.plugins.push(
       new webpack.DefinePlugin({
         SERVER: process.env.GH_PAGES ? JSON.stringify('/frontend/') : JSON.stringify('/'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6928,11 +6928,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz"
-  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
-
 fswin@^2.17.1227:
   version "2.17.1227"
   resolved "https://registry.npmjs.org/fswin/-/fswin-2.17.1227.tgz"


### PR DESCRIPTION
Storybook images did not render as the fs package did not fix the bug. 
The solution here is to set a env.var instead, that should set the variable when gh pages builds, which means we can set the subdirectory as a part of the path to the images.

We have tested setting the variable on a linux computer and it works, but we still have not tested with the deployment pipeline using yaml

The fs package is removed as it is not needed anyways.