### PR TITLE
KURSP-914 get the language that is selected and use that to translate label

### DIFF
--- a/src/vue/components/course-modules/CourseModule.vue
+++ b/src/vue/components/course-modules/CourseModule.vue
@@ -32,7 +32,7 @@
       <li v-for="course in nodes" :key="course.id">
         <TreeView
           :type="course.type"
-          :label="extractLabelForSelectedLanguage(course.label, 'nb')"
+          :label="extractLabelForSelectedLanguage(course.label,getSelectedLanguage())"
           :id="course.id"
           :url="course.url? course.url : ''"
           :nodes="course.nodes"
@@ -46,10 +46,10 @@
 </template>
 
 <script setup>
-import { ref, computed, defineProps, defineEmits } from 'vue';
+import { ref, computed, defineProps, defineEmits} from 'vue';
 import Icon from '../icon/Icon.vue';
 import TreeView from '../tree-view/TreeView.vue';
-import { extractLabelForSelectedLanguage } from '../../utils/lang-utils';
+import { extractLabelForSelectedLanguage, getSelectedLanguage } from '../../utils/lang-utils';
 
 
 const props = defineProps({
@@ -61,7 +61,6 @@ const props = defineProps({
 });
 
 const emits = defineEmits(['toggleActiveModule']);
-
 const collapsed = ref(true);
 const selectedNode = ref(-1);
 

--- a/src/vue/components/course-modules/CourseModules.vue
+++ b/src/vue/components/course-modules/CourseModules.vue
@@ -14,7 +14,7 @@
       >
         <CourseModule
           :type="module.type"
-          :label="extractLabelForSelectedLanguage(module.label, 'nb')"
+          :label="extractLabelForSelectedLanguage(module.label,getSelectedLanguage())"
           :id="module.id"
           :nodes="module.nodes"
           :isActive="isActiveModule(module.id)"
@@ -29,7 +29,7 @@
 import { defineProps, ref } from 'vue';
 import Icon from '../icon/Icon.vue';
 import CourseModule from './CourseModule.vue';
-import { extractLabelForSelectedLanguage } from '../../utils/lang-utils';
+import { extractLabelForSelectedLanguage, getSelectedLanguage } from '../../utils/lang-utils';
 
 
 const props = defineProps({
@@ -39,6 +39,7 @@ const props = defineProps({
 const treestructure = props.nodes; // Assign nodes prop to treestructure
 
 const selectedNode = ref(-1);
+
 
 const toggleActiveModule = ({moduleId, isOpen}) => {
   if (selectedNode.value === moduleId) {

--- a/src/vue/components/tree-view/TreeView.vue
+++ b/src/vue/components/tree-view/TreeView.vue
@@ -25,7 +25,7 @@
       <li v-for="node in nodes" :key="node.id" class="tree-node__child-nodes__node">
         <TreeView
           :type="node.type"
-          :label="extractLabelForSelectedLanguage(node.label, 'nb')"
+          :label="extractLabelForSelectedLanguage(node.label, getSelectedLanguage())"
           :id="node.id"
           :nodes="node.nodes"
           :url = "node.url? node.url : ''"
@@ -41,7 +41,7 @@
 <script setup>
 import { ref, computed, defineProps, defineEmits } from 'vue';
 import Icon from '../icon/Icon.vue';
-import { extractLabelForSelectedLanguage } from '../../utils/lang-utils';
+import { extractLabelForSelectedLanguage, getSelectedLanguage } from '../../utils/lang-utils';
 
 const props = defineProps({
   type: String,

--- a/src/vue/utils/lang-utils.js
+++ b/src/vue/utils/lang-utils.js
@@ -1,3 +1,4 @@
+import multilanguage from "../../js/3party/multilanguage";
 /**
  * Cleans a string to extract content based on a specified language code.
  * @param {string} label - The input string containing language-specific content.
@@ -31,4 +32,9 @@ export function extractLabelForSelectedLanguage(label, param) {
 
   // If there's no language codes or matches, return the label as is.
   return label;
+}
+
+export function getSelectedLanguage() {
+  return multilanguage.getLanguageParameter();
+  
 }


### PR DESCRIPTION
Using utility functions that already exist, but import it to the vue/utils, to keep the dependencies to the outside on  a minimum per component.

Translating the labels of the Module selector

<img width="1220" alt="image" src="https://github.com/matematikk-mooc/frontend/assets/11961516/f6e55abe-05ce-4ec4-8a58-d8751c26cefa">
