### PR TITLE
KURSP-1158: Module progressor counts pages with 'isCompleted'

### DIFF
--- a/src/vue/components/course-modules/completed-utils.js
+++ b/src/vue/components/course-modules/completed-utils.js
@@ -5,22 +5,16 @@ export function countPagesAndCompleted(entry) {
   const pages = [];
 
   function processNode(node) {
-    if (node.type === 'page') {
-      totalPages++;
-      pages.push(node)
-
+    if (node.type === 'page' || node.type === 'discussion' || node.type === 'quiz') {
+      if ("isCompleted" in node) {
+        totalPages++;
+      }
 
       if (node.isCompleted) {
         completedPages++;
       }
-    }
-    else if (node.type === 'discussion' || node.type === 'quiz') {
-      totalPages++;
+
       pages.push(node);
-
-      if (node.isCompleted) {
-        completedPages++;
-      }
     }
     else if (node.type === 'module') {
       node.nodes.forEach((child) => processNode(child));
@@ -28,6 +22,7 @@ export function countPagesAndCompleted(entry) {
   }
 
   processNode(entry);
+
   return {
     id: entry.id,
     totalPages,


### PR DESCRIPTION
    The module progressor now shows progression based on pages with
    the 'isCompleted' key and how many of these keys have the value true
    By pages i here mean page, discussion and quiz node types.
    This should give an accurate description of both the module
    progression and the progression towards earning a diploma.