### PR TITLE
KURSP-1166: Add workflow_dispatch to workflow files

### DIFF
--- a/.github/workflows/build-dev-push-azure.yml
+++ b/.github/workflows/build-dev-push-azure.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - dev
+  workflow_dispatch:
+
 env:
   ACCOUNT_NAME: udirdit
   SOURCE: dist

--- a/.github/workflows/build-master-push-azure.yml
+++ b/.github/workflows/build-master-push-azure.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
 env:
   ACCOUNT_NAME: udirdit
   SOURCE: dist


### PR DESCRIPTION
    Seems that in order to run workflow files other than on main
    branch from either cli or webgui they need to contain
    'workflow_dispatch' under 'on'.
    This has been added to:
        - build-dev-push-azure.yml
        - build-master-push-azure.yml