### PR TITLE
DIT-137: Added support for url navigated course previews on frontpage

### DIFF
--- a/src/vue/components/modal/Modal.vue
+++ b/src/vue/components/modal/Modal.vue
@@ -105,7 +105,7 @@ const closeModal = () => {
       word-wrap: break-word;
       padding:0.5rem 1rem 0.5rem 1rem;
       width: 100%;
-      overflow-y:scroll;
+      overflow-y:auto;
    }
 
     &__actions {

--- a/src/vue/utils/url-utils.js
+++ b/src/vue/utils/url-utils.js
@@ -1,0 +1,21 @@
+/**
+ * Adds, updates, or removes a parameter in the current URL without refreshing the page.
+ * @param {string} param - The name of the parameter to add, update, or remove.
+ * @param {string|null} value - The value of the parameter. If set to `null`, the parameter will be removed.
+ * @returns {string} The modified URL.
+ */
+export function shallowUpdateUrlParameter(param, value) {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (value === null) {
+        urlParams.delete(param);
+    } else {
+        urlParams.set(param, value);
+    }
+
+    const baseUrl = window.location.pathname;
+    const newParams = urlParams.toString();
+    const newUrl = baseUrl + (newParams ? '?' + newParams : '');
+
+    window.history.pushState({ path: newUrl }, '', newUrl);
+    return newUrl;
+}


### PR DESCRIPTION
- Updated: Course preview to push the ID to URL so that users can share the link directly to the modal
- Added: Url utililty to handle changes without refreshes/shallow updates on query parameters
- Updated: CSS for modal to remove scroll bar if there is no scrolling length
- Updated: Course preview modal to remove duplicate close buttons and show go to course if already enrolled