### PR TITLE
DIT-531: Hint format

### DIFF
--- a/src/vue/design/re-styles/tooltip.scss
+++ b/src/vue/design/re-styles/tooltip.scss
@@ -9,6 +9,7 @@
     outline: 3px solid dimgray;
     .tooltiptext-box {
         display: inline !important;
+        word-wrap: normal;
     }
 }
 
@@ -39,6 +40,7 @@
     gap: 1rem;
     z-index: 1;
     box-shadow: rgba(0, 0, 0, 0.24) 0px 3px 8px;
+    word-break: normal !important;
     
     .close-tooltip {
         cursor: pointer;


### PR DESCRIPTION
Fixed issue where hints sometimes inherit word-wrap styling, forcing the tooltip to become wrong size.
---

Changed

- Removed word-wrap override.

---

## Checklist
-   [x] Make sure both security and lint tests have passed since continue-on-error is enabled.
-   [x] Add a short description of the changes. (will be used for public changelog)
-   [x] Fill out Added, Changed, Removed, Fixed and remove any unused lists (will be used for public changelog)
